### PR TITLE
Stop polling server while page is hidden

### DIFF
--- a/panserver.py
+++ b/panserver.py
@@ -256,6 +256,9 @@ def create_header(autorefresh):
         headertext += """
     <script>
     window.setInterval(function() {
+        if (document.visibilityState === 'hidden') {
+            return;
+        }
         var xhr = new XMLHttpRequest();
         var href = window.location.href;
         var re = /view\/(.+?)$/;


### PR DESCRIPTION
Use the page visibility API to stop pages from polling the server for
updates while hidden. This saves a small amount of CPU time.